### PR TITLE
arreglo de error de bootstrap con popper

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -36,7 +36,6 @@
               "node_modules/swiper/swiper-bundle.min.css"
             ],
             "scripts": [
-              "node_modules/bootstrap/dist/js/bootstrap.min.js",
               "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js",
               "node_modules/swiper/swiper-bundle.min.js"
             ]


### PR DESCRIPTION
Se eliminó "node_modules/bootstrap/dist/js/bootstrap.min.js" de los scripts ya que angular utiliza unicamente "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js", al estar ambos puestos en los scripts se generaba conflictos en la carga de modulos